### PR TITLE
Add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM gcc:14-bookworm AS builder
+
+RUN apt update && apt install cmake libcyaml-dev libjson-c-dev -y
+
+COPY . /app
+WORKDIR /app
+
+RUN mkdir -p log && touch log/caster.log
+RUN cmake -S . -B $(pwd)/build -DCMAKE_BUILD_TYPE=Release
+RUN cmake --build $(pwd)/build
+
+
+FROM scratch
+
+USER 1000
+
+ENTRYPOINT ["/app/caster"]
+COPY --from=builder --chown=1000 /app/log/caster.log /var/log/millipede/caster.log
+COPY --from=builder --chown=1000 /app/sample-config/ /usr/local/etc/millipede/
+COPY --from=builder /app/build/caster /app/caster


### PR DESCRIPTION
A dockerfile is easier for people without the correct pre-requisite to build and test the caster.