### PR TITLE
chore(ci): Add actions to test on PR and do release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: simple build and test
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake libcyaml-dev libjson-c-dev libevent-dev lcov -y
+
+      - name: Create makefile
+        run: |
+          cmake -S . -B $(pwd)/cmake-build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"
+
+      - name: Build
+        run: |
+          cmake --build $(pwd)/cmake-build --config Release
+
+      #- name: Run tests
+      #  run: |
+      #    exec test
+      #
+
+      #- name: Generate coverage report
+      #  run: |
+      #    cd $(pwd)/cmake-build
+      #    lcov --capture --directory . --output-file coverage.info
+      #    lcov --remove coverage.info '/usr/*' --output-file coverage.info
+      #    lcov --list coverage.info

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: simple build and test
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake libcyaml-dev libjson-c-dev libevent-dev -y
+
+      - name: Create makefile
+        run: |
+          cmake -S . -B $(pwd)/cmake-build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: |
+          cmake --build $(pwd)/cmake-build --config Release
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mv $(pwd)/cmake-build/caster $(pwd)/cmake-build/caster-linux-x64
+          gh release upload ${{github.event.release.tag_name}} $(pwd)/cmake-build/caster-linux-x64        
+


### PR DESCRIPTION
I created those 2 actions.

The first one will build the caster when a PR is created to master/main  or when a push is made on master/main. The goal is to validate that the caster build.
Note: When a PR is from a fork, you will have to validate the content of the PR before accepting the workflow to run.

The second action is a way to set a build when a release is triggered. Here an example of the result.

![image](https://github.com/user-attachments/assets/3cd87659-7ebe-4c6a-8ae8-af60bc7c6d66)
