### PR TITLE
Fix warnings

### DIFF
--- a/caster/jobs.c
+++ b/caster/jobs.c
@@ -4,6 +4,7 @@
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
 #include <pthread.h>
+#include <sched.h>
 #include <signal.h>
 #include <unistd.h>
 
@@ -528,7 +529,7 @@ int jobs_start_threads(struct joblist *this, int nthreads) {
 void jobs_stop_threads(struct joblist *this) {
 	for (int i = 0; i < this->nthreads; i++) {
 		joblist_append_stop(this);
-		pthread_yield();
+		sched_yield();
 	}
 
 	int r, nlive;

--- a/caster/jobs.c
+++ b/caster/jobs.c
@@ -20,8 +20,8 @@ struct joblist *joblist_new(struct caster_state *caster) {
 	struct joblist *this = (struct joblist *)malloc(sizeof(struct joblist));
 	if (this != NULL) {
 		if (pthread_cond_init(&this->condjob, NULL) != 0) {
-			free(this);
 			caster_log_error(this->caster, "pthread_cond_init");
+			free(this);
 			return NULL;
 		}
 		this->ntrip_njobs = 0;


### PR DESCRIPTION
cmake reports 2 warnings

- pthread_yield is deprecated adn should be replace by sched_yield
- there is a use-after-free